### PR TITLE
Fix wrong descriptions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ Github Action for running the docstr-coverage python package
 ### Available options for use in action 'with'
 - source_dir 
   - Directory containing python code
-  - **Required** (str) Example: /src
+  - **Required** (str) Example: `source_dir: src`
             
-- failure_percentage 
+- fail_under 
   - Coverage percentage required to be considered passing
   - **Optional** (int) Defaults to 100
   
@@ -45,7 +45,7 @@ Github Action for running the docstr-coverage python package
 
 - badge:
   - Generate a docstring coverage percent badge as an SVG saved to a given filepath
-  - **Optional** (bool) Defaults to false
+  - **Optional** (filepath) Disabled if not set. (Example: `badge: docs/docstr-badge.svg`)
 
 - follow_links:
   - Follow symlinks
@@ -69,7 +69,7 @@ jobs:
         uses: actions/checkout@v1
 
       - name: docstr-coverage should fail
-        uses: skazazes-work/docstr-coverage@v1
+        uses: KlexosNYC/docstr-coverage-action@v1.4
         with:
-          source_dir: /src
+          source_dir: src
 ```


### PR DESCRIPTION
Hello. Thank you so much for sharing `docstr-coverage-action`. This action is very useful for me. However, some descriptions in README are not correct. So I corrected the errors I found as follows.

### 1. `use` in the example section

`uses: skazazes-work/docstr-coverage@v1` is not working. So changed to `uses: KlexosNYC/docstr-coverage-action@v1.4`

### 2. `source_dir` option

`source_dir: /src` gave me the following error.

```sh
docstr-coverage --verbose 3 --fail-under 100 --skip-magic --skip-init --skip-file-doc --skip-private --skip-class-def --accept-empty --badge true --follow-links --percentage-only /github/workspace//src

Error: Invalid value for '[PATHS]...': Path '/github/workspace//src' does not exist.
```

So it changed to `source_dir: src`.

### 3. `failure_percentage` option

This option does not exist and raises the following error.

```sh
Warning: Unexpected input(s) 'failure_percentage', valid inputs are ['entryPoint', 'args', 'source_dir', 'fail_under', 'skip_magic', 'skip_init', 'skip_file_doc', 'skip_private', 'skip_class_def', 'accept_empty', 'docstr_ignore_file', 'exclude', 'verbose', 'badge', 'follow_links', 'percentage_only']
```

So it changed to `fail_under`.

### 4. `badge` option

The README says this option is boolean, but I think it is a path string. Because when I set it to `badge: true`, I found in the log that the following command passed.

```sh
docstr-coverage ... --badge true ...
```

And actually got the file `true.svg`.
So it changed from `(bool)` to `(filepath)`.

I hope this PR will help this repository.